### PR TITLE
fix: prepare npm package

### DIFF
--- a/exports.jsonc
+++ b/exports.jsonc
@@ -1,0 +1,12 @@
+{
+    // TODO: this should be added to package.json once typescript supports node export maps
+    // https://github.com/microsoft/TypeScript/issues/33079
+    "exports": {
+        ".": "./build/index.js",
+        "./vendors/ethers/": "./build/vendors/ethers/index.js",
+        "./vendors/ethers/*": "./build/vendors/ethers/*.js",
+        "./vendors/web3/": "./build/vendors/web3/index.js",
+        "./vendors/web3/*": "./build/vendors/web3/*.js",
+        "./package.json": "./package.json"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "1.0.2",
   "description": "Javascript library for working with the Swivel Finance Protocol",
   "main": "build/index.js",
+  "module": "build/index.js",
   "types": "build/index.d.ts",
+  "files": [
+    "/build",
+    "/src/**/*.ts"
+  ],
   "author": "swivel-finance",
   "license": "MIT",
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,3 @@ export * from './constants';
 export * from './interfaces';
 export * from './marketplace';
 export * from './swivel';
-export * from './vendors';

--- a/src/vendors/index.ts
+++ b/src/vendors/index.ts
@@ -1,2 +1,0 @@
-export * from './ethers';
-export * from './web3';

--- a/test/swivel.spec.ts
+++ b/test/swivel.spec.ts
@@ -3,8 +3,9 @@ import { getDefaultProvider, Provider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import { assert } from 'chai';
 import { stub } from 'sinon';
-import { EthersSwivelContract, EthersVendor, Order, prepareOrder, splitSignature, Swivel, TxResponse } from '../src';
+import { Order, Swivel, TxResponse } from '../src';
 import { CHAIN_ID_AND_VERIFYING_CONTRACT_REQUIRED, MISSING_CONTRACT_ADDRESS } from '../src/errors';
+import { EthersSwivelContract, EthersVendor, prepareOrder, splitSignature } from '../src/vendors/ethers';
 import { TEST_HELPERS } from './test-helpers';
 
 describe('swivel', () => {

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,5 +1,6 @@
 import { Contract } from '@ethersproject/contracts';
-import { EthersMarketplaceContract, EthersSwivelContract, Marketplace, Swivel } from '../src';
+import { Marketplace, Swivel } from '../src';
+import { EthersMarketplaceContract, EthersSwivelContract } from '../src/vendors/ethers';
 
 interface HasContract<TContract> {
     contract: TContract;

--- a/test/vendors/ethers/ethers.spec.ts
+++ b/test/vendors/ethers/ethers.spec.ts
@@ -3,7 +3,8 @@ import { getDefaultProvider, Provider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import { assert } from 'chai';
 import { BigNumber, ethers, utils } from 'ethers';
-import { EthersMarketplaceContract, EthersSwivelContract, EthersVendor, MARKETPLACE_ABI, Order, prepareAmount, prepareOrder, splitSignature, SWIVEL_ABI } from '../../../src';
+import { MARKETPLACE_ABI, Order, SWIVEL_ABI } from '../../../src';
+import { EthersMarketplaceContract, EthersSwivelContract, EthersVendor, prepareAmount, prepareOrder, splitSignature } from '../../../src/vendors/ethers';
 
 describe('vendors/ethers', () => {
 


### PR DESCRIPTION
don't export vendors from main entry point, as this will force browsers and bundlers to resolve `ethers.js` and `web3.js`