### PR TITLE
fix!: update contracts post audit

### DIFF
--- a/src/constants/abi/market-place.ts
+++ b/src/constants/abi/market-place.ts
@@ -366,7 +366,7 @@ export const MARKET_PLACE_ABI = [
         'inputs': [
             {
                 'internalType': 'address',
-                'name': 'a',
+                'name': 'u',
                 'type': 'address',
             },
             {
@@ -389,11 +389,6 @@ export const MARKET_PLACE_ABI = [
     {
         'inputs': [
             {
-                'internalType': 'address',
-                'name': 'u',
-                'type': 'address',
-            },
-            {
                 'internalType': 'uint256',
                 'name': 'm',
                 'type': 'uint256',
@@ -412,11 +407,6 @@ export const MARKET_PLACE_ABI = [
                 'internalType': 'string',
                 'name': 's',
                 'type': 'string',
-            },
-            {
-                'internalType': 'uint8',
-                'name': 'd',
-                'type': 'uint8',
             },
         ],
         'name': 'createMarket',
@@ -538,29 +528,10 @@ export const MARKET_PLACE_ABI = [
                 'name': 'vaultAddr',
                 'type': 'address',
             },
-        ],
-        'stateMutability': 'view',
-        'type': 'function',
-    },
-    {
-        'inputs': [
-            {
-                'internalType': 'address',
-                'name': '',
-                'type': 'address',
-            },
             {
                 'internalType': 'uint256',
-                'name': '',
+                'name': 'maturityRate',
                 'type': 'uint256',
-            },
-        ],
-        'name': 'mature',
-        'outputs': [
-            {
-                'internalType': 'bool',
-                'name': '',
-                'type': 'bool',
             },
         ],
         'stateMutability': 'view',
@@ -588,30 +559,6 @@ export const MARKET_PLACE_ABI = [
             },
         ],
         'stateMutability': 'nonpayable',
-        'type': 'function',
-    },
-    {
-        'inputs': [
-            {
-                'internalType': 'address',
-                'name': '',
-                'type': 'address',
-            },
-            {
-                'internalType': 'uint256',
-                'name': '',
-                'type': 'uint256',
-            },
-        ],
-        'name': 'maturityRate',
-        'outputs': [
-            {
-                'internalType': 'uint256',
-                'name': '',
-                'type': 'uint256',
-            },
-        ],
-        'stateMutability': 'view',
         'type': 'function',
     },
     {
@@ -729,6 +676,38 @@ export const MARKET_PLACE_ABI = [
     {
         'inputs': [
             {
+                'internalType': 'bool',
+                'name': 'b',
+                'type': 'bool',
+            },
+        ],
+        'name': 'pause',
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [],
+        'name': 'paused',
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
                 'internalType': 'address',
                 'name': 'u',
                 'type': 'address',
@@ -819,6 +798,25 @@ export const MARKET_PLACE_ABI = [
             },
         ],
         'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'address',
+                'name': 'a',
+                'type': 'address',
+            },
+        ],
+        'name': 'transferAdmin',
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
+        'stateMutability': 'nonpayable',
         'type': 'function',
     },
     {

--- a/src/constants/abi/swivel.ts
+++ b/src/constants/abi/swivel.ts
@@ -17,8 +17,27 @@ export const SWIVEL_ABI = [
         'inputs': [
             {
                 'indexed': true,
+                'internalType': 'address',
+                'name': 'token',
+                'type': 'address',
+            },
+        ],
+        'name': 'BlockWithdrawal',
+        'type': 'event',
+    },
+    {
+        'anonymous': false,
+        'inputs': [
+            {
+                'indexed': true,
                 'internalType': 'bytes32',
                 'name': 'key',
+                'type': 'bytes32',
+            },
+            {
+                'indexed': false,
+                'internalType': 'bytes32',
+                'name': 'hash',
                 'type': 'bytes32',
             },
         ],
@@ -32,6 +51,12 @@ export const SWIVEL_ABI = [
                 'indexed': true,
                 'internalType': 'bytes32',
                 'name': 'key',
+                'type': 'bytes32',
+            },
+            {
+                'indexed': false,
+                'internalType': 'bytes32',
+                'name': 'hash',
                 'type': 'bytes32',
             },
             {
@@ -81,6 +106,12 @@ export const SWIVEL_ABI = [
                 'indexed': true,
                 'internalType': 'bytes32',
                 'name': 'key',
+                'type': 'bytes32',
+            },
+            {
+                'indexed': false,
+                'internalType': 'bytes32',
+                'name': 'hash',
                 'type': 'bytes32',
             },
             {
@@ -139,7 +170,26 @@ export const SWIVEL_ABI = [
                 'type': 'uint256',
             },
         ],
-        'name': 'WithdrawalScheduled',
+        'name': 'ScheduleWithdrawal',
+        'type': 'event',
+    },
+    {
+        'anonymous': false,
+        'inputs': [
+            {
+                'indexed': true,
+                'internalType': 'uint256',
+                'name': 'index',
+                'type': 'uint256',
+            },
+            {
+                'indexed': true,
+                'internalType': 'uint256',
+                'name': 'feenominator',
+                'type': 'uint256',
+            },
+        ],
+        'name': 'SetFee',
         'type': 'event',
     },
     {
@@ -150,6 +200,19 @@ export const SWIVEL_ABI = [
                 'internalType': 'uint256',
                 'name': '',
                 'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [],
+        'name': 'MIN_FEENOMINATOR',
+        'outputs': [
+            {
+                'internalType': 'uint16',
+                'name': '',
+                'type': 'uint16',
             },
         ],
         'stateMutability': 'view',
@@ -197,13 +260,43 @@ export const SWIVEL_ABI = [
     {
         'inputs': [
             {
+                'internalType': 'address[]',
+                'name': 'u',
+                'type': 'address[]',
+            },
+            {
+                'internalType': 'address[]',
+                'name': 'c',
+                'type': 'address[]',
+            },
+        ],
+        'name': 'approveUnderlying',
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
                 'internalType': 'address',
                 'name': 'e',
                 'type': 'address',
             },
         ],
         'name': 'blockWithdrawal',
-        'outputs': [],
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
         'stateMutability': 'nonpayable',
         'type': 'function',
     },
@@ -457,7 +550,7 @@ export const SWIVEL_ABI = [
                 'type': 'uint256',
             },
         ],
-        'name': 'fenominator',
+        'name': 'feenominators',
         'outputs': [
             {
                 'internalType': 'uint16',
@@ -655,7 +748,13 @@ export const SWIVEL_ABI = [
             },
         ],
         'name': 'scheduleWithdrawal',
-        'outputs': [],
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
         'stateMutability': 'nonpayable',
         'type': 'function',
     },
@@ -663,7 +762,7 @@ export const SWIVEL_ABI = [
         'inputs': [
             {
                 'internalType': 'uint16',
-                'name': 't',
+                'name': 'i',
                 'type': 'uint16',
             },
             {
@@ -716,12 +815,37 @@ export const SWIVEL_ABI = [
         'inputs': [
             {
                 'internalType': 'address',
+                'name': 'a',
+                'type': 'address',
+            },
+        ],
+        'name': 'transferAdmin',
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'address',
                 'name': 'e',
                 'type': 'address',
             },
         ],
         'name': 'withdraw',
-        'outputs': [],
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
         'stateMutability': 'nonpayable',
         'type': 'function',
     },

--- a/src/constants/abi/vault-tracker.ts
+++ b/src/constants/abi/vault-tracker.ts
@@ -97,7 +97,13 @@ export const VAULT_TRACKER_ABI = [
         'type': 'function',
     },
     {
-        'inputs': [],
+        'inputs': [
+            {
+                'internalType': 'uint256',
+                'name': 'c',
+                'type': 'uint256',
+            },
+        ],
         'name': 'matureVault',
         'outputs': [
             {
@@ -107,19 +113,6 @@ export const VAULT_TRACKER_ABI = [
             },
         ],
         'stateMutability': 'nonpayable',
-        'type': 'function',
-    },
-    {
-        'inputs': [],
-        'name': 'matured',
-        'outputs': [
-            {
-                'internalType': 'bool',
-                'name': '',
-                'type': 'bool',
-            },
-        ],
-        'stateMutability': 'view',
         'type': 'function',
     },
     {

--- a/src/interfaces/contracts/market-place.ts
+++ b/src/interfaces/contracts/market-place.ts
@@ -5,6 +5,7 @@ export interface Market {
     cTokenAddr: string;
     zcTokenAddr: string;
     vaultAddr: string;
+    maturityRate: string;
 }
 
 export interface MarketPlaceContract {
@@ -22,28 +23,17 @@ export interface MarketPlaceContract {
     swivel (): Promise<string>;
 
     /**
+     * Returns the paused status.
+     */
+    paused (): Promise<boolean>;
+
+    /**
      * Retrieve the market information.
      *
      * @param u - underlying token address associated with the market
      * @param m - maturity timestamp of the market
      */
     markets (u: string, m: uint256): Promise<Market>;
-
-    /**
-     * Checks if a market is mature.
-     *
-     * @param u - underlying token address associated with the market
-     * @param m - maturity timestamp of the market
-     */
-    mature (u: string, m: uint256): Promise<boolean>;
-
-    /**
-     * Retrieve the market maturity.
-     *
-     * @param u - underlying token address associated with the market
-     * @param m - maturity timestamp of the market
-     */
-    maturityRate (u: string, m: uint256): Promise<string>;
 
     /**
      * @param u - underlying token address associated with the market

--- a/src/interfaces/contracts/vault-tracker.ts
+++ b/src/interfaces/contracts/vault-tracker.ts
@@ -30,11 +30,6 @@ export interface VaultTrackerContract {
     maturity (): Promise<string>;
 
     /**
-     * Checks if the maturity date is reached.
-     */
-    matured (): Promise<boolean>;
-
-    /**
      * Returns the maturity rate.
      */
     maturityRate (): Promise<string>;

--- a/src/market-place.ts
+++ b/src/market-place.ts
@@ -86,6 +86,16 @@ export class MarketPlace implements MarketPlaceContract {
     }
 
     /**
+     * Returns the paused status.
+     */
+    async paused (): Promise<boolean> {
+
+        if (!this.contract) throw MISSING_CONTRACT_ADDRESS('market-place');
+
+        return await this.contract.paused();
+    }
+
+    /**
      * Retrieve the market information.
      *
      * @param u - underlying token address associated with the market
@@ -96,32 +106,6 @@ export class MarketPlace implements MarketPlaceContract {
         if (!this.contract) throw MISSING_CONTRACT_ADDRESS('market-place');
 
         return await this.contract.markets(u, m);
-    }
-
-    /**
-     * Checks if a market is mature.
-     *
-     * @param u - underlying token address associated with the market
-     * @param m - maturity timestamp of the market
-     */
-    async mature (u: string, m: uint256): Promise<boolean> {
-
-        if (!this.contract) throw MISSING_CONTRACT_ADDRESS('market-place');
-
-        return await this.contract.mature(u, m);
-    }
-
-    /**
-     * Retrieve the market maturity.
-     *
-     * @param u - underlying token address associated with the market
-     * @param m - maturity timestamp of the market
-     */
-    async maturityRate (u: string, m: uint256): Promise<string> {
-
-        if (!this.contract) throw MISSING_CONTRACT_ADDRESS('market-place');
-
-        return await this.contract.maturityRate(u, m);
     }
 
     /**

--- a/src/vault-tracker.ts
+++ b/src/vault-tracker.ts
@@ -99,16 +99,6 @@ export class VaultTracker implements VaultTrackerContract {
     }
 
     /**
-     * Checks if the maturity date is reached.
-     */
-    async matured (): Promise<boolean> {
-
-        if (!this.contract) throw MISSING_CONTRACT_ADDRESS('vault-tracker');
-
-        return await this.contract.matured();
-    }
-
-    /**
      * Returns the maturity rate.
      */
     async maturityRate (): Promise<string> {

--- a/src/vendors/ethers/contracts/market-place.ts
+++ b/src/vendors/ethers/contracts/market-place.ts
@@ -11,6 +11,7 @@ type MarketResponse = string[] & {
     cTokenAddr: string;
     zcTokenAddr: string;
     vaultAddr: string;
+    maturityRate: ethers.BigNumber;
 };
 
 export class EthersMarketPlaceContract implements MarketPlaceContract {
@@ -49,6 +50,14 @@ export class EthersMarketPlaceContract implements MarketPlaceContract {
     }
 
     /**
+     * Returns the associated swivel contract address.
+     */
+    async paused (): Promise<boolean> {
+
+        return unwrap<boolean>(await this.contract.functions.paused());
+    }
+
+    /**
      * Retrieve the market information.
      *
      * @param u - underlying token address associated with the market
@@ -74,35 +83,8 @@ export class EthersMarketPlaceContract implements MarketPlaceContract {
             cTokenAddr: market.cTokenAddr,
             zcTokenAddr: market.zcTokenAddr,
             vaultAddr: market.vaultAddr,
+            maturityRate: fromBigNumber(market.maturityRate),
         };
-    }
-
-    /**
-     * Checks if a market is mature.
-     *
-     * @param u - underlying token address associated with the market
-     * @param m - maturity timestamp of the market
-     */
-    async mature (u: string, m: uint256): Promise<boolean> {
-
-        const maturity = toBigNumber(m);
-
-        return unwrap<boolean>(await this.contract.functions.mature(u, maturity));
-    }
-
-    /**
-     * Retrieve the market maturity.
-     *
-     * @param u - underlying token address associated with the market
-     * @param m - maturity timestamp of the market
-     */
-    async maturityRate (u: string, m: uint256): Promise<string> {
-
-        const maturity = toBigNumber(m);
-
-        const maturityRate = unwrap<ethers.BigNumber>(await this.contract.functions.maturityRate(u, maturity));
-
-        return fromBigNumber(maturityRate);
     }
 
     /**

--- a/src/vendors/ethers/contracts/vault-tracker.ts
+++ b/src/vendors/ethers/contracts/vault-tracker.ts
@@ -65,14 +65,6 @@ export class EthersVaultTrackerContract implements VaultTrackerContract {
     }
 
     /**
-     * Checks if the maturity date is reached.
-     */
-    async matured (): Promise<boolean> {
-
-        return unwrap<boolean>(await this.contract.functions.matured());
-    }
-
-    /**
      * Returns the maturity rate.
      */
     async maturityRate (): Promise<string> {

--- a/test/market-place.spec.ts
+++ b/test/market-place.spec.ts
@@ -87,6 +87,24 @@ describe('MarketPlace', () => {
 
             await assertThrows(marketPlace, 'admin');
         });
+
+        it('unwraps the contract `Result`', async () => {
+
+            const vendor = new EthersVendor(provider, signer);
+            const marketPlace = new MarketPlace(vendor).at(deployedAddress);
+
+            // get a stubbable (configurable) clone of the underlying `ethers.Contract`
+            const contract = TEST_HELPERS.marketPlace.ethers.stubVendorContract(marketPlace);
+
+            // stub the admin getter of the `ethers.Contract`
+            const mock = stub(contract.functions, 'admin');
+            const mockResponse = ['0xadmin'] as Result<[string]>;
+            mock.resolves(mockResponse);
+
+            const response = await marketPlace.admin();
+
+            assert.strictEqual(response, '0xadmin');
+        });
     });
 
     describe('swivel', () => {
@@ -97,6 +115,53 @@ describe('MarketPlace', () => {
             const marketPlace = new MarketPlace(vendor);
 
             await assertThrows(marketPlace, 'swivel');
+        });
+
+        it('unwraps the contract `Result`', async () => {
+
+            const vendor = new EthersVendor(provider, signer);
+            const marketPlace = new MarketPlace(vendor).at(deployedAddress);
+
+            // get a stubbable (configurable) clone of the underlying `ethers.Contract`
+            const contract = TEST_HELPERS.marketPlace.ethers.stubVendorContract(marketPlace);
+
+            // stub the swivel getter of the `ethers.Contract`
+            const mock = stub(contract.functions, 'swivel');
+            const mockResponse = ['0xswivel'] as Result<[string]>;
+            mock.resolves(mockResponse);
+
+            const response = await marketPlace.swivel();
+
+            assert.strictEqual(response, '0xswivel');
+        });
+    });
+
+    describe('paused', () => {
+
+        it('throws if deployed contract is not wrapped', async () => {
+
+            const vendor = new EthersVendor(provider, signer);
+            const marketPlace = new MarketPlace(vendor);
+
+            await assertThrows(marketPlace, 'paused');
+        });
+
+        it('unwraps the contract `Result`', async () => {
+
+            const vendor = new EthersVendor(provider, signer);
+            const marketPlace = new MarketPlace(vendor).at(deployedAddress);
+
+            // get a stubbable (configurable) clone of the underlying `ethers.Contract`
+            const contract = TEST_HELPERS.marketPlace.ethers.stubVendorContract(marketPlace);
+
+            // stub the paused getter of the `ethers.Contract`
+            const mock = stub(contract.functions, 'paused');
+            const mockResponse = [true] as Result<[boolean]>;
+            mock.resolves(mockResponse);
+
+            const response = await marketPlace.paused();
+
+            assert.strictEqual(response, true);
         });
     });
 
@@ -124,6 +189,7 @@ describe('MarketPlace', () => {
                 cTokenAddr: '0xcToken',
                 zcTokenAddr: '0xzcToken',
                 vaultAddr: '0xvault',
+                maturityRate: '1',
             };
             mock.resolves(mockResponse);
 
@@ -133,90 +199,6 @@ describe('MarketPlace', () => {
 
             // we should receive the mocked response
             assert.deepStrictEqual(response, mockResponse);
-            assert.isTrue(mock.calledOnce);
-
-            // the underlying `ethers.Contract` should be invoked with vendor specific conversions of the arguments
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            const [passedUnderlying, passedMaturity] = mock.getCall(0).args;
-            const expectedUnderlying = underlying;
-            const expectedMaturity = ethers.BigNumber.from(maturity);
-
-            assert.deepStrictEqual(passedUnderlying, expectedUnderlying);
-            assert.deepStrictEqual(passedMaturity, expectedMaturity);
-        });
-    });
-
-    describe('mature', () => {
-
-        it('throws if deployed contract is not wrapped', async () => {
-
-            const vendor = new EthersVendor(provider, signer);
-            const marketPlace = new MarketPlace(vendor);
-
-            await assertThrows(marketPlace, 'mature');
-        });
-
-        it('converts arguments and passes them to vendor specific contract instance', async () => {
-
-            const vendor = new EthersVendor(provider, signer);
-            const marketPlace = new MarketPlace(vendor).at(deployedAddress);
-
-            // get a stubbable (configurable) clone of the underlying `ethers.Contract`
-            const contract = TEST_HELPERS.marketPlace.ethers.stubVendorContract(marketPlace);
-
-            // stub the mature function of the `ethers.Contract`
-            const mock = stub(contract.functions, 'mature');
-            const mockResponse = [true] as Result<[boolean]>;
-            mock.resolves(mockResponse);
-
-            const underlying = '0xunderlying';
-            const maturity = 1640987320;
-            const response = await marketPlace.mature(underlying, maturity);
-
-            // we should receive the unwrapped mocked response
-            assert.strictEqual(response, true);
-            assert.isTrue(mock.calledOnce);
-
-            // the underlying `ethers.Contract` should be invoked with vendor specific conversions of the arguments
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            const [passedUnderlying, passedMaturity] = mock.getCall(0).args;
-            const expectedUnderlying = underlying;
-            const expectedMaturity = ethers.BigNumber.from(maturity);
-
-            assert.deepStrictEqual(passedUnderlying, expectedUnderlying);
-            assert.deepStrictEqual(passedMaturity, expectedMaturity);
-        });
-    });
-
-    describe('maturityRate', () => {
-
-        it('throws if deployed contract is not wrapped', async () => {
-
-            const vendor = new EthersVendor(provider, signer);
-            const marketPlace = new MarketPlace(vendor);
-
-            await assertThrows(marketPlace, 'maturityRate');
-        });
-
-        it('converts arguments and passes them to vendor specific contract instance', async () => {
-
-            const vendor = new EthersVendor(provider, signer);
-            const marketPlace = new MarketPlace(vendor).at(deployedAddress);
-
-            // get a stubbable (configurable) clone of the underlying `ethers.Contract`
-            const contract = TEST_HELPERS.marketPlace.ethers.stubVendorContract(marketPlace);
-
-            // stub the maturityRate function of the `ethers.Contract`
-            const mock = stub(contract.functions, 'maturityRate');
-            const mockResponse = [ethers.BigNumber.from(0)] as Result<[ethers.BigNumber]>;
-            mock.resolves(mockResponse);
-
-            const underlying = '0xunderlying';
-            const maturity = 1640987320;
-            const response = await marketPlace.maturityRate(underlying, maturity);
-
-            // we should receive the unwrapped mocked response
-            assert.strictEqual(response, '0');
             assert.isTrue(mock.calledOnce);
 
             // the underlying `ethers.Contract` should be invoked with vendor specific conversions of the arguments

--- a/test/vault-tracker.spec.ts
+++ b/test/vault-tracker.spec.ts
@@ -96,7 +96,7 @@ describe('VaultTracker', () => {
             // get a stubbable (configurable) clone of the underlying `ethers.Contract`
             const contract = TEST_HELPERS.vaultTracker.ethers.stubVendorContract(vaultTracker);
 
-            // stub the vaultTracker getter of the `ethers.Contract`
+            // stub the admin getter of the `ethers.Contract`
             const mock = stub(contract.functions, 'admin');
             const mockResponse = ['0xadminAddress'] as Result<[string]>;
             mock.resolves(mockResponse);
@@ -125,7 +125,7 @@ describe('VaultTracker', () => {
             // get a stubbable (configurable) clone of the underlying `ethers.Contract`
             const contract = TEST_HELPERS.vaultTracker.ethers.stubVendorContract(vaultTracker);
 
-            // stub the vaultTracker getter of the `ethers.Contract`
+            // stub the swivel getter of the `ethers.Contract`
             const mock = stub(contract.functions, 'swivel');
             const mockResponse = ['0xswivelAddress'] as Result<[string]>;
             mock.resolves(mockResponse);
@@ -145,16 +145,23 @@ describe('VaultTracker', () => {
 
             await assertThrows(vaultTracker, 'maturity');
         });
-    });
 
-    describe('matured', () => {
-
-        it('throws if deployed contract is not wrapped', async () => {
+        it('unwraps the contract `Result`', async () => {
 
             const vendor = new EthersVendor(provider, signer);
-            const vaultTracker = new VaultTracker(vendor);
+            const vaultTracker = new VaultTracker(vendor).at(deployedAddress);
 
-            await assertThrows(vaultTracker, 'matured');
+            // get a stubbable (configurable) clone of the underlying `ethers.Contract`
+            const contract = TEST_HELPERS.vaultTracker.ethers.stubVendorContract(vaultTracker);
+
+            // stub the maturity getter of the `ethers.Contract`
+            const mock = stub(contract.functions, 'maturity');
+            const mockResponse = ['123456'] as Result<[string]>;
+            mock.resolves(mockResponse);
+
+            const response = await vaultTracker.maturity();
+
+            assert.strictEqual(response, '123456');
         });
     });
 
@@ -167,6 +174,24 @@ describe('VaultTracker', () => {
 
             await assertThrows(vaultTracker, 'maturityRate');
         });
+
+        it('unwraps the contract `Result`', async () => {
+
+            const vendor = new EthersVendor(provider, signer);
+            const vaultTracker = new VaultTracker(vendor).at(deployedAddress);
+
+            // get a stubbable (configurable) clone of the underlying `ethers.Contract`
+            const contract = TEST_HELPERS.vaultTracker.ethers.stubVendorContract(vaultTracker);
+
+            // stub the maturityRate getter of the `ethers.Contract`
+            const mock = stub(contract.functions, 'maturityRate');
+            const mockResponse = ['1'] as Result<[string]>;
+            mock.resolves(mockResponse);
+
+            const response = await vaultTracker.maturityRate();
+
+            assert.strictEqual(response, '1');
+        });
     });
 
     describe('cTokenAddr', () => {
@@ -177,6 +202,24 @@ describe('VaultTracker', () => {
             const vaultTracker = new VaultTracker(vendor);
 
             await assertThrows(vaultTracker, 'cTokenAddr');
+        });
+
+        it('unwraps the contract `Result`', async () => {
+
+            const vendor = new EthersVendor(provider, signer);
+            const vaultTracker = new VaultTracker(vendor).at(deployedAddress);
+
+            // get a stubbable (configurable) clone of the underlying `ethers.Contract`
+            const contract = TEST_HELPERS.vaultTracker.ethers.stubVendorContract(vaultTracker);
+
+            // stub the cTokenAddr getter of the `ethers.Contract`
+            const mock = stub(contract.functions, 'cTokenAddr');
+            const mockResponse = ['0xcToken'] as Result<[string]>;
+            mock.resolves(mockResponse);
+
+            const response = await vaultTracker.cTokenAddr();
+
+            assert.strictEqual(response, '0xcToken');
         });
     });
 
@@ -189,6 +232,29 @@ describe('VaultTracker', () => {
 
             await assertThrows(vaultTracker, 'vaults');
         });
+
+        it('unwraps the contract `Result`', async () => {
+
+            const vendor = new EthersVendor(provider, signer);
+            const vaultTracker = new VaultTracker(vendor).at(deployedAddress);
+
+            // get a stubbable (configurable) clone of the underlying `ethers.Contract`
+            const contract = TEST_HELPERS.vaultTracker.ethers.stubVendorContract(vaultTracker);
+
+            // stub the vaults method of the `ethers.Contract`
+            const mock = stub(contract.functions, 'vaults');
+            const mockResponse = {
+                notional: '0',
+                redeemable: '0',
+                exchangeRate: '1',
+            };
+            mock.resolves(mockResponse);
+
+            const owner = '0xowner';
+            const response = await vaultTracker.vaults(owner);
+
+            assert.deepStrictEqual(response, mockResponse);
+        });
     });
 
     describe('balancesOf', () => {
@@ -199,6 +265,25 @@ describe('VaultTracker', () => {
             const vaultTracker = new VaultTracker(vendor);
 
             await assertThrows(vaultTracker, 'balancesOf');
+        });
+
+        it('unwraps the contract `Result`', async () => {
+
+            const vendor = new EthersVendor(provider, signer);
+            const vaultTracker = new VaultTracker(vendor).at(deployedAddress);
+
+            // get a stubbable (configurable) clone of the underlying `ethers.Contract`
+            const contract = TEST_HELPERS.vaultTracker.ethers.stubVendorContract(vaultTracker);
+
+            // stub the balancesOf method of the `ethers.Contract`
+            const mock = stub(contract.functions, 'balancesOf');
+            const mockResponse = ['0', '0'] as [string, string];
+            mock.resolves(mockResponse);
+
+            const owner = '0xowner';
+            const response = await vaultTracker.balancesOf(owner);
+
+            assert.deepStrictEqual(response, mockResponse);
         });
     });
 });


### PR DESCRIPTION
BREAKING CHANGE: `mature()` and `maturityRate()` have been removed from `MarketPlace` contract;
BREAKING CHANGE: `matured()` has been removed from `VaultTracker` contract;
the `Market` interface now has an additional property `maturityRate`