### PR TITLE
fix: handle parsing of MetaMask gas estimation errors

### DIFF
--- a/src/constants/abi/market-place.ts
+++ b/src/constants/abi/market-place.ts
@@ -42,9 +42,7 @@ export const MARKET_PLACE_ABI = [
         'type': 'error',
     },
     {
-        'inputs': [
-
-        ],
+        'inputs': [],
         'name': 'RATE',
         'type': 'error',
     },
@@ -412,9 +410,7 @@ export const MARKET_PLACE_ABI = [
         'type': 'event',
     },
     {
-        'inputs': [
-
-        ],
+        'inputs': [],
         'name': 'admin',
         'outputs': [
             {
@@ -578,9 +574,7 @@ export const MARKET_PLACE_ABI = [
         'type': 'function',
     },
     {
-        'inputs': [
-
-        ],
+        'inputs': [],
         'name': 'creator',
         'outputs': [
             {
@@ -693,7 +687,7 @@ export const MARKET_PLACE_ABI = [
                 'type': 'address',
             },
         ],
-        'name': 'exchangeRate',
+        'name': 'getExchangeRate',
         'outputs': [
             {
                 'internalType': 'uint256',
@@ -1059,9 +1053,7 @@ export const MARKET_PLACE_ABI = [
         'type': 'function',
     },
     {
-        'inputs': [
-
-        ],
+        'inputs': [],
         'name': 'swivel',
         'outputs': [
             {

--- a/src/contracts/market-place.ts
+++ b/src/contracts/market-place.ts
@@ -178,6 +178,7 @@ export class MarketPlace {
         return (this.constructor as typeof MarketPlace).interestRate(p, a, this.contract.provider);
     }
 
+    // TODO: this method will be named `exchangeRate` in the final version, which conflicts with the methods above...
     /**
      * Retrieve the exchange rate for a lending protocol and cToken/pool using Swivel's ICompounding abstraction.
      *

--- a/src/contracts/market-place.ts
+++ b/src/contracts/market-place.ts
@@ -179,6 +179,19 @@ export class MarketPlace {
     }
 
     /**
+     * Retrieve the exchange rate for a lending protocol and cToken/pool using Swivel's ICompounding abstraction.
+     *
+     * @param p - protocol enum value of the lending protocol associated with a swivel market
+     * @param a - address of the market's cToken
+     * @param t - optional transaction overrides
+     * @returns the exchange rate of the protocol's cToken/pool to underlying (the scale of the value depends on the protocol)
+     */
+    async getExchangeRate (p: Protocols, a: string, t: CallOverrides = {}): Promise<string> {
+
+        return unwrap<BigNumber>(await this.contract.functions.getExchangeRate(p, a, t)).toString();
+    }
+
+    /**
      * Get a market's cToken address.
      *
      * @param p - protocol enum value associated with the market pair

--- a/src/errors/error.ts
+++ b/src/errors/error.ts
@@ -45,14 +45,14 @@ export class SwivelError extends Error {
 /**
  * Parses the custom error data from an `UNPREDICTABLE_GAS_LIMIT` or `CALL_EXCEPTION` error.
  *
- * @param error - an ethers error/rejection reason that may contain custom error data
- * @returns a {@link SwivelError} if the error contains custom error data, `undefined` otherwise
+ * @param errorOrData - an ethers error/rejection reason that may contain custom error data or a string representing the abi-encoded exception data
+ * @returns a {@link SwivelError} if `errorOrData` contains custom error data, `undefined` otherwise
  *
  * @example
  */
-export const parseSwivelError = (error: unknown): SwivelError | undefined => {
+export const parseSwivelError = (errorOrData: unknown): SwivelError | undefined => {
 
-    const exception = parseException(error);
+    const exception = parseException(errorOrData);
 
     if (exception) {
 

--- a/src/errors/error.ts
+++ b/src/errors/error.ts
@@ -45,14 +45,14 @@ export class SwivelError extends Error {
 /**
  * Parses the custom error data from an `UNPREDICTABLE_GAS_LIMIT` or `CALL_EXCEPTION` error.
  *
- * @param errorOrData - an ethers error/rejection reason that may contain custom error data or a string representing the abi-encoded exception data
+ * @param e - an ethers error/rejection reason that may contain custom error data or a string representing the abi-encoded exception data
  * @returns a {@link SwivelError} if `errorOrData` contains custom error data, `undefined` otherwise
  *
  * @example
  */
-export const parseSwivelError = (errorOrData: unknown): SwivelError | undefined => {
+export const parseSwivelError = (e: unknown): SwivelError | undefined => {
 
-    const exception = parseException(errorOrData);
+    const exception = parseException(e);
 
     if (exception) {
 

--- a/src/errors/exception.ts
+++ b/src/errors/exception.ts
@@ -1,6 +1,6 @@
 import { utils } from 'ethers';
 import { SWIVEL_ABI } from '../constants/index.js';
-import { Exception, ExceptionResult, isStaticCallError, isUnpredictableGasLimitError } from './types.js';
+import { Exception, ExceptionResult, isStaticCallError, isUnpredictableGasLimitError, JsonRpcProviderError, MetaMaskProviderRpcError } from './types.js';
 
 // swivel abi for decoding exception data
 const SWIVEL_INTERFACE = new utils.Interface(SWIVEL_ABI);
@@ -11,21 +11,28 @@ const SWIVEL_ERROR_FRAGMENT = 'Exception';
 /**
  * Parses the custom error data from an `UNPREDICTABLE_GAS_LIMIT` or `CALL_EXCEPTION` error.
  *
- * @param error - an ethers error/rejection reason that may contain custom error data
- * @returns an {@link Exception} if the error contains custom error data, `undefined` otherwise
+ * @param errorOrData - an ethers error/rejection reason that may contain custom error data or a string representing the abi-encoded exception data
+ * @returns an {@link Exception} if `errorOrData` contains custom error data, `undefined` otherwise
  *
  * @example
  */
-export const parseException = (error: unknown): Exception | undefined => {
+export const parseException = (errorOrData: unknown): Exception | undefined => {
 
-    // parse custom error data from an unpredictable gas limit error
-    if (isUnpredictableGasLimitError(error)) {
+    const data = (typeof errorOrData === 'string')
+        ? errorOrData
+        : isUnpredictableGasLimitError(errorOrData)
+            // extract custom error data from an unpredictable gas limit error - they are abi-encoded
+            ? (errorOrData.error as JsonRpcProviderError)?.error?.error?.data ?? (errorOrData.error as MetaMaskProviderRpcError)?.data?.originalError?.data
+            : undefined;
+
+    if (data) {
 
         try {
 
+            // parse custom error data from an abi-encoded data string
             const [code, amount, amountExpected, address, addressExpected] = SWIVEL_INTERFACE.decodeErrorResult(
                 SWIVEL_ERROR_FRAGMENT,
-                error.error.error.error.data,
+                data,
             ) as ExceptionResult;
 
             return {
@@ -41,12 +48,11 @@ export const parseException = (error: unknown): Exception | undefined => {
             // if we can't successfully parse the error data, there wasn't a custom error
             // we can ignore that and return undefined
         }
-    }
 
-    // parse custom error data from a `callStatic` call exception
-    if (isStaticCallError(error)) {
+    } else if (isStaticCallError(errorOrData)) {
 
-        const [code, amount, amountExpected, address, addressExpected] = error.errorArgs as ExceptionResult;
+        // extract custom error data from a `callStatic` call exception - they are parsed by ethers already
+        const [code, amount, amountExpected, address, addressExpected] = errorOrData.errorArgs as ExceptionResult;
 
         return {
             code,

--- a/src/errors/exception.ts
+++ b/src/errors/exception.ts
@@ -11,18 +11,18 @@ const SWIVEL_ERROR_FRAGMENT = 'Exception';
 /**
  * Parses the custom error data from an `UNPREDICTABLE_GAS_LIMIT` or `CALL_EXCEPTION` error.
  *
- * @param errorOrData - an ethers error/rejection reason that may contain custom error data or a string representing the abi-encoded exception data
+ * @param e - an ethers error/rejection reason that may contain custom error data or a string representing the abi-encoded exception data
  * @returns an {@link Exception} if `errorOrData` contains custom error data, `undefined` otherwise
  *
  * @example
  */
-export const parseException = (errorOrData: unknown): Exception | undefined => {
+export const parseException = (e: unknown): Exception | undefined => {
 
-    const data = (typeof errorOrData === 'string')
-        ? errorOrData
-        : isUnpredictableGasLimitError(errorOrData)
+    const data = (typeof e === 'string')
+        ? e
+        : isUnpredictableGasLimitError(e)
             // extract custom error data from an unpredictable gas limit error - they are abi-encoded
-            ? (errorOrData.error as JsonRpcProviderError)?.error?.error?.data ?? (errorOrData.error as MetaMaskProviderRpcError)?.data?.originalError?.data
+            ? (e.error as JsonRpcProviderError)?.error?.error?.data ?? (e.error as MetaMaskProviderRpcError)?.data?.originalError?.data
             : undefined;
 
     if (data) {
@@ -49,10 +49,10 @@ export const parseException = (errorOrData: unknown): Exception | undefined => {
             // we can ignore that and return undefined
         }
 
-    } else if (isStaticCallError(errorOrData)) {
+    } else if (isStaticCallError(e)) {
 
         // extract custom error data from a `callStatic` call exception - they are parsed by ethers already
-        const [code, amount, amountExpected, address, addressExpected] = errorOrData.errorArgs as ExceptionResult;
+        const [code, amount, amountExpected, address, addressExpected] = e.errorArgs as ExceptionResult;
 
         return {
             code,

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -282,18 +282,18 @@ export interface StaticCallError {
 /**
  * A typeguard for {@link UnpredictableGasLimitError}s.
  */
-export const isUnpredictableGasLimitError = (error: unknown): error is UnpredictableGasLimitError => {
+export const isUnpredictableGasLimitError = (e: unknown): e is UnpredictableGasLimitError => {
 
-    return (error as UnpredictableGasLimitError).code === 'UNPREDICTABLE_GAS_LIMIT'
-        && !!(error as UnpredictableGasLimitError).error;
+    return (e as UnpredictableGasLimitError).code === 'UNPREDICTABLE_GAS_LIMIT'
+        && !!(e as UnpredictableGasLimitError).error;
 };
 
 /**
  * A typeguard for {@link StaticCallError}s.
  */
-export const isStaticCallError = (error: unknown): error is StaticCallError => {
+export const isStaticCallError = (e: unknown): e is StaticCallError => {
 
-    return (error as StaticCallError).code === 'CALL_EXCEPTION'
-        && (error as StaticCallError).errorName === 'Exception'
-        && (error as StaticCallError).errorArgs?.length > 0;
+    return (e as StaticCallError).code === 'CALL_EXCEPTION'
+        && (e as StaticCallError).errorName === 'Exception'
+        && (e as StaticCallError).errorArgs?.length > 0;
 };

--- a/test/contracts/market-place.spec.ts
+++ b/test/contracts/market-place.spec.ts
@@ -152,13 +152,66 @@ suite('marketplace', () => {
         });
     });
 
+    suite('getExchangeRate', () => {
+
+        const protocol = Protocols.Compound;
+        const address = '0xcTokenAddress';
+
+        const expected = '21382742901237490012';
+
+        test('converts arguments, unwraps and converts result', async () => {
+
+            const marketplace = new MarketPlace(ADDRESSES.MARKET_PLACE, provider);
+
+            const getExchangeRate = mockMethod<string>(marketplace, 'getExchangeRate');
+            getExchangeRate.resolves([expected]);
+
+            const result = await marketplace.getExchangeRate(protocol, address);
+
+            assert.deepStrictEqual(result, expected);
+            assert(getExchangeRate.calledOnce);
+
+            const args = getExchangeRate.getCall(0).args;
+
+            assert.strictEqual(args.length, 3);
+
+            const [passedProtocol, passedAddress, passedOverrides] = args;
+
+            assert.strictEqual(passedProtocol, protocol);
+            assert.strictEqual(passedAddress, address);
+            assert.deepStrictEqual(passedOverrides, {});
+        });
+
+        test('accepts transaction overrides', async () => {
+
+            const marketplace = new MarketPlace(ADDRESSES.MARKET_PLACE, provider);
+
+            const getExchangeRate = mockMethod<string>(marketplace, 'getExchangeRate');
+            getExchangeRate.resolves([expected]);
+
+            const result = await marketplace.getExchangeRate(protocol, address, callOverrides);
+
+            assert.deepStrictEqual(result, expected);
+            assert(getExchangeRate.calledOnce);
+
+            const args = getExchangeRate.getCall(0).args;
+
+            assert.strictEqual(args.length, 3);
+
+            const [passedProtocol, passedAddress, passedOverrides] = args;
+
+            assert.strictEqual(passedProtocol, protocol);
+            assert.strictEqual(passedAddress, address);
+            assert.deepStrictEqual(passedOverrides, callOverrides);
+        });
+    });
+
     suite('cTokenAddress', () => {
 
         const protocol = Protocols.Compound;
         const underlying = '0xunderlying';
         const maturity = '1656526007';
 
-        // an expected tuple result
         const expected = '0xcToken';
 
         test('converts arguments, unwraps and converts result', async () => {

--- a/test/test-helpers/mock.ts
+++ b/test/test-helpers/mock.ts
@@ -129,6 +129,7 @@ export function clone<T = unknown> (o: T): T {
 
 export const mockExecutor = (): TransactionExecutor => {
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return async (c: Contract, m: string, a: unknown[], t: PayableOverrides = {}, o = false) => {
 
         // the mocked executor will skip `callStatic` and `estimateGas` during tests and invoke


### PR DESCRIPTION
add type defs for MetaMask's `ProviderRpcError`;
change detection logic for `isUnpredictableGasLimitError`;
allow direct parsing of abi-encoded error data strings;
add `getExchangeRate` method to MarketPlace hoc;
fix Exception code 33 & 34;
update tests;

fixes #93
fixes #94