### PR TITLE
fix(swivel): update `cancel` method

### DIFF
--- a/docs/swivel.md
+++ b/docs/swivel.md
@@ -729,12 +729,10 @@ A promise that resolves with an ethers `TransactionResponse` if the contract cal
 
 Allows a user to cancel their order(s).
 
-Signatures can be supplied as `string` (signature hash), `Signature` (object with R, S, V components) or `number[]` (byte arrays).
-
 ### Signature
 
 ```typescript
-cancel (o: Order[], s: SignatureLike[], t: PayableOverrides = {}): Promise<TransactionResponse>;
+cancel (o: Order[], t: PayableOverrides = {}): Promise<TransactionResponse>;
 ```
 
 ### Parameters
@@ -742,7 +740,6 @@ cancel (o: Order[], s: SignatureLike[], t: PayableOverrides = {}): Promise<Trans
 |Paramater|Type|Description|
 |---------|----|-----------|
 |o|`Order[]`|An array of order objects to be cancelled.|
-|s|`SignatureLike[]`|An array of valid 132 byte ECDSA signatures relative to  the orders.|
 |t|`PayableOverrides`|Optional transaction overrides.|
 
 ### Returns

--- a/src/constants/abi/market-place.ts
+++ b/src/constants/abi/market-place.ts
@@ -366,6 +366,19 @@ export const MARKET_PLACE_ABI = [
         'inputs': [
             {
                 'indexed': true,
+                'internalType': 'address',
+                'name': 'admin',
+                'type': 'address',
+            },
+        ],
+        'name': 'SetAdmin',
+        'type': 'event',
+    },
+    {
+        'anonymous': false,
+        'inputs': [
+            {
+                'indexed': true,
                 'internalType': 'uint8',
                 'name': 'protocol',
                 'type': 'uint8',

--- a/src/constants/abi/swivel.ts
+++ b/src/constants/abi/swivel.ts
@@ -294,6 +294,12 @@ export const SWIVEL_ABI = [
         'inputs': [
             {
                 'indexed': false,
+                'internalType': 'uint16[4]',
+                'name': 'proposal',
+                'type': 'uint16[4]',
+            },
+            {
+                'indexed': false,
                 'internalType': 'uint256',
                 'name': 'hold',
                 'type': 'uint256',
@@ -319,6 +325,19 @@ export const SWIVEL_ABI = [
             },
         ],
         'name': 'ScheduleWithdrawal',
+        'type': 'event',
+    },
+    {
+        'anonymous': false,
+        'inputs': [
+            {
+                'indexed': true,
+                'internalType': 'address',
+                'name': 'admin',
+                'type': 'address',
+            },
+        ],
+        'name': 'SetAdmin',
         'type': 'event',
     },
     {
@@ -601,31 +620,9 @@ export const SWIVEL_ABI = [
                         'type': 'uint256',
                     },
                 ],
-                'internalType': 'struct Hash.Order',
+                'internalType': 'struct Hash.Order[]',
                 'name': 'o',
-                'type': 'tuple',
-            },
-            {
-                'components': [
-                    {
-                        'internalType': 'uint8',
-                        'name': 'v',
-                        'type': 'uint8',
-                    },
-                    {
-                        'internalType': 'bytes32',
-                        'name': 'r',
-                        'type': 'bytes32',
-                    },
-                    {
-                        'internalType': 'bytes32',
-                        'name': 's',
-                        'type': 'bytes32',
-                    },
-                ],
-                'internalType': 'struct Sig.Components',
-                'name': 'c',
-                'type': 'tuple',
+                'type': 'tuple[]',
             },
         ],
         'name': 'cancel',
@@ -1103,7 +1100,11 @@ export const SWIVEL_ABI = [
     },
     {
         'inputs': [
-
+            {
+                'internalType': 'uint16[4]',
+                'name': 'f',
+                'type': 'uint16[4]',
+            },
         ],
         'name': 'scheduleFeeChange',
         'outputs': [

--- a/src/contracts/swivel.ts
+++ b/src/contracts/swivel.ts
@@ -270,15 +270,13 @@ export class Swivel {
      * Cancel an order.
      *
      * @param o - array of swivel orders
-     * @param s - array of valid ECDSA signatures relative to passed orders
      * @param t - optional transaction overrides
      */
-    async cancel (o: Order[], s: SignatureLike[], t: PayableOverrides = {}): Promise<TransactionResponse> {
+    async cancel (o: Order[], t: PayableOverrides = {}): Promise<TransactionResponse> {
 
         const orders = o.map(order => parseOrder(order));
-        const signatures = s.map(signature => utils.splitSignature(signature));
 
-        return await this.executor(this.contract, 'cancel', [orders, signatures], t);
+        return await this.executor(this.contract, 'cancel', [orders], t);
     }
 
     /**

--- a/test/contracts/swivel.spec.ts
+++ b/test/contracts/swivel.spec.ts
@@ -580,7 +580,6 @@ suite('swivel', () => {
     suite('cancel', () => {
 
         const order = mockOrder();
-        const signature = mockSignature();
 
         test('converts arguments', async () => {
 
@@ -590,19 +589,18 @@ suite('swivel', () => {
             const response = mockResponse();
             cancel.resolves(response);
 
-            const result = await swivel.cancel([order], [signature]);
+            const result = await swivel.cancel([order]);
 
             assert.strictEqual(result.hash, response.hash);
             assert(cancel.calledOnce);
 
             const args = cancel.getCall(0).args;
 
-            assert.strictEqual(args.length, 3);
+            assert.strictEqual(args.length, 2);
 
-            const [passedOrders, passedSignatures, passedOverrides] = args;
+            const [passedOrders, passedOverrides] = args;
 
             assert.deepStrictEqual(passedOrders, [parseOrder(order)]);
-            assert.deepStrictEqual(passedSignatures, [utils.splitSignature(signature)]);
             assert.deepStrictEqual(passedOverrides, {});
         });
 
@@ -614,19 +612,18 @@ suite('swivel', () => {
             const response = mockResponse();
             cancel.resolves(response);
 
-            const result = await swivel.cancel([order], [signature], payableOverrides);
+            const result = await swivel.cancel([order], payableOverrides);
 
             assert.strictEqual(result.hash, response.hash);
             assert(cancel.calledOnce);
 
             const args = cancel.getCall(0).args;
 
-            assert.strictEqual(args.length, 3);
+            assert.strictEqual(args.length, 2);
 
-            const [passedOrders, passedSignatures, passedOverrides] = args;
+            const [passedOrders, passedOverrides] = args;
 
             assert.deepStrictEqual(passedOrders, [parseOrder(order)]);
-            assert.deepStrictEqual(passedSignatures, [utils.splitSignature(signature)]);
             assert.deepStrictEqual(passedOverrides, payableOverrides);
         });
     });


### PR DESCRIPTION
the cancel method does not take a signature array any longer;

fixes #98