### PR TITLE
fix(swivel): fix the approvals map

### DIFF
--- a/docs/swivel.md
+++ b/docs/swivel.md
@@ -571,19 +571,20 @@ A promise that resolves with the token's hold timestamp if the contract call suc
 
 Allows a user to retrieve a token's approval hold.
 
-When a token approval is scheduled, a timestamp is generated using the current time plus the `HOLD` time and stored in the `approvals` map using the token address as key. This map lets a user access these scheduled approval "holds" per token address.
+When a token approval is scheduled, a timestamp is generated using the current time plus the `HOLD` time and stored in the `approvals` map using the token address and the approved contract address as keys. This map lets a user access these scheduled approval "holds" per token and contract address.
 
 ### Signature
 
 ```typescript
-approvals (a: string, t: CallOverrides = {}): Promise<string>;
+approvals (e: string, a: string, t: CallOverrides = {}): Promise<string>;
 ```
 
 ### Parameters
 
 |Paramater|Type|Description|
 |---------|----|-----------|
-|a|`string`|The token address to check.|
+|e|`string`|The (ERC20) token address to check.|
+|a|`string`|The approved contract address to check.|
 |t|`CallOverrides`|Optional transaction overrides.|
 
 ### Returns

--- a/src/constants/abi/swivel.ts
+++ b/src/constants/abi/swivel.ts
@@ -97,6 +97,12 @@ export const SWIVEL_ABI = [
                 'name': 'token',
                 'type': 'address',
             },
+            {
+                'indexed': true,
+                'internalType': 'address',
+                'name': 'blocked',
+                'type': 'address',
+            },
         ],
         'name': 'BlockApproval',
         'type': 'event',
@@ -280,6 +286,12 @@ export const SWIVEL_ABI = [
                 'type': 'address',
             },
             {
+                'indexed': true,
+                'internalType': 'address',
+                'name': 'approved',
+                'type': 'address',
+            },
+            {
                 'indexed': false,
                 'internalType': 'uint256',
                 'name': 'hold',
@@ -437,6 +449,11 @@ export const SWIVEL_ABI = [
                 'name': '',
                 'type': 'address',
             },
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
         ],
         'name': 'approvals',
         'outputs': [
@@ -517,6 +534,11 @@ export const SWIVEL_ABI = [
             {
                 'internalType': 'address',
                 'name': 'e',
+                'type': 'address',
+            },
+            {
+                'internalType': 'address',
+                'name': 'a',
                 'type': 'address',
             },
         ],
@@ -1084,6 +1106,11 @@ export const SWIVEL_ABI = [
             {
                 'internalType': 'address',
                 'name': 'e',
+                'type': 'address',
+            },
+            {
+                'internalType': 'address',
+                'name': 'a',
                 'type': 'address',
             },
         ],

--- a/src/contracts/swivel.ts
+++ b/src/contracts/swivel.ts
@@ -224,12 +224,13 @@ export class Swivel {
     /**
      * Retrieve a token's hold after which an approval can be made.
      *
-     * @param a - the token address
+     * @param e - the (ERC20) token address to approve
+     * @param e - the contract address to approve
      * @param t - optional transaction overrides
      */
-    async approvals (a: string, t: CallOverrides = {}): Promise<string> {
+    async approvals (e: string, a: string, t: CallOverrides = {}): Promise<string> {
 
-        return unwrap<BigNumber>(await this.contract.functions.approvals(a, t)).toString();
+        return unwrap<BigNumber>(await this.contract.functions.approvals(e, a, t)).toString();
     }
 
     /**

--- a/test/contracts/swivel.spec.ts
+++ b/test/contracts/swivel.spec.ts
@@ -359,14 +359,14 @@ suite('swivel', () => {
 
         test('unwraps result and accepts transaction overrides', async () => {
 
-            const address = '0xtokenAddress';
+            const token = '0xtokenAddress';
             const expected = '1656526007';
 
             const swivel = new Swivel(ADDRESSES.SWIVEL, signer);
             const withdrawals = mockMethod<BigNumber>(swivel, 'withdrawals');
             withdrawals.resolves([BigNumber.from(expected)]);
 
-            let result = await swivel.withdrawals(address);
+            let result = await swivel.withdrawals(token);
 
             assert.strictEqual(result, expected);
             assert(withdrawals.calledOnce);
@@ -375,14 +375,14 @@ suite('swivel', () => {
 
             assert.strictEqual(args.length, 2);
 
-            let [passedOrderKey, passedOverrides] = args;
+            let [passedToken, passedOverrides] = args;
 
-            assert.strictEqual(passedOrderKey, address);
+            assert.strictEqual(passedToken, token);
             assert.deepStrictEqual(passedOverrides, {});
 
             // call with transaction overrides
 
-            result = await swivel.withdrawals(address, callOverrides);
+            result = await swivel.withdrawals(token, callOverrides);
 
             assert.strictEqual(result, expected);
             assert(withdrawals.calledTwice);
@@ -391,9 +391,9 @@ suite('swivel', () => {
 
             assert.strictEqual(args.length, 2);
 
-            [passedOrderKey, passedOverrides] = args;
+            [passedToken, passedOverrides] = args;
 
-            assert.strictEqual(passedOrderKey, address);
+            assert.strictEqual(passedToken, token);
             assert.deepStrictEqual(passedOverrides, callOverrides);
         });
     });
@@ -402,41 +402,44 @@ suite('swivel', () => {
 
         test('unwraps result and accepts transaction overrides', async () => {
 
-            const address = '0xtokenAddress';
+            const token = '0xtokenAddress';
+            const contract = '0xcontractAddress';
             const expected = '1656526007';
 
             const swivel = new Swivel(ADDRESSES.SWIVEL, signer);
             const approvals = mockMethod<BigNumber>(swivel, 'approvals');
             approvals.resolves([BigNumber.from(expected)]);
 
-            let result = await swivel.approvals(address);
+            let result = await swivel.approvals(token, contract);
 
             assert.strictEqual(result, expected);
             assert(approvals.calledOnce);
 
             let args = approvals.getCall(0).args;
 
-            assert.strictEqual(args.length, 2);
+            assert.strictEqual(args.length, 3);
 
-            let [passedOrderKey, passedOverrides] = args;
+            let [passedToken, passedContract, passedOverrides] = args;
 
-            assert.strictEqual(passedOrderKey, address);
+            assert.strictEqual(passedToken, token);
+            assert.strictEqual(passedContract, contract);
             assert.deepStrictEqual(passedOverrides, {});
 
             // call with transaction overrides
 
-            result = await swivel.approvals(address, callOverrides);
+            result = await swivel.approvals(token, contract, callOverrides);
 
             assert.strictEqual(result, expected);
             assert(approvals.calledTwice);
 
             args = approvals.getCall(1).args;
 
-            assert.strictEqual(args.length, 2);
+            assert.strictEqual(args.length, 3);
 
-            [passedOrderKey, passedOverrides] = args;
+            [passedToken, passedContract, passedOverrides] = args;
 
-            assert.strictEqual(passedOrderKey, address);
+            assert.strictEqual(passedToken, token);
+            assert.strictEqual(passedContract, contract);
             assert.deepStrictEqual(passedOverrides, callOverrides);
         });
     });


### PR DESCRIPTION
approvals now has nested keys to allow for parallel approval scheduling of the same ERC20 to multiple contracts