### PR TITLE
fix: ensure interest rate returns fixed notation

### DIFF
--- a/src/internal/rates/helpers/constants.ts
+++ b/src/internal/rates/helpers/constants.ts
@@ -1,5 +1,17 @@
+/**
+ * A base value with 27 decimals.
+ *
+ * @remarks
+ * Used by Aave and Euler to scale various rates.
+ */
 export const RAY = '1000000000000000000000000000';
 
+/**
+ * A base value with 26 decimals.
+ *
+ * @remarks
+ * Used by Swivel to scale ERC4626 and Euler rates.
+ */
 export const BASE = '100000000000000000000000000';
 
 export const BASE_DECIMALS = 26;

--- a/src/internal/rates/helpers/index.ts
+++ b/src/internal/rates/helpers/index.ts
@@ -25,3 +25,17 @@ export const fixed = (v: BigNumberish, d = BASE_DECIMALS): FixedNumber => {
 
     return FixedNumber.from(v, d);
 };
+
+/**
+ * Stringify a number ensuring no exponential notations.
+ *
+ * @remarks
+ * Trailing zeros are removed from the result.
+ *
+ * @param v - number
+ * @param d - precision (number of decimals)
+ */
+export const stringify = (v: number, d = BASE_DECIMALS): string => {
+
+    return v.toFixed(d).replace(/(?<!\.)0+$/, '');
+};

--- a/src/internal/rates/protocols/aave/aave.ts
+++ b/src/internal/rates/protocols/aave/aave.ts
@@ -2,7 +2,7 @@ import { Provider } from '@ethersproject/abstract-provider';
 import { Signer } from '@ethersproject/abstract-signer';
 import { Contract } from 'ethers';
 import { SECONDS_PER_YEAR } from '../../../../constants/index.js';
-import { fixed } from '../../helpers/index.js';
+import { fixed, stringify } from '../../helpers/index.js';
 import { AAVE_MANTISSA, AAVE_POOL_ABI, AAVE_TOKEN_ABI } from './constants.js';
 import { AavePoolContract, AaveTokenContract } from './types.js';
 
@@ -59,5 +59,5 @@ export async function interestRateAave (a: string, s: Provider | Signer): Promis
     // compound the supply rate and derive the supply APY
     const supplyAPY = Math.pow(Number(supplyRate.toString()) / SECONDS_PER_YEAR + 1, SECONDS_PER_YEAR) - 1;
 
-    return supplyAPY.toString();
+    return stringify(supplyAPY);
 }

--- a/src/internal/rates/protocols/cerc-20/cerc-20.ts
+++ b/src/internal/rates/protocols/cerc-20/cerc-20.ts
@@ -2,6 +2,7 @@ import { Provider } from '@ethersproject/abstract-provider';
 import { Signer } from '@ethersproject/abstract-signer';
 import { Contract } from 'ethers';
 import { BLOCKS_PER_DAY, DAYS_PER_YEAR } from '../../../../constants/index.js';
+import { stringify } from '../../helpers/index.js';
 import { CERC20_ABI, CERC20_MANTISSA } from './constants.js';
 import { CERC20Contract } from './types.js';
 
@@ -36,7 +37,9 @@ export async function interestRateCERC20 (a: string, s: Provider | Signer): Prom
 
     const contract = new Contract(a, CERC20_ABI, s) as CERC20Contract;
 
-    const rate = (await contract.supplyRatePerBlock()).toString();
+    const supplyRate = (await contract.supplyRatePerBlock()).toString();
 
-    return (Math.pow(Number(rate) / CERC20_MANTISSA * BLOCKS_PER_DAY + 1, DAYS_PER_YEAR) - 1).toString();
+    const supplyAPY = Math.pow(Number(supplyRate) / CERC20_MANTISSA * BLOCKS_PER_DAY + 1, DAYS_PER_YEAR) - 1;
+
+    return stringify(supplyAPY);
 }

--- a/src/internal/rates/protocols/euler/euler.ts
+++ b/src/internal/rates/protocols/euler/euler.ts
@@ -4,7 +4,7 @@ import { Contract } from 'ethers';
 import { SECONDS_PER_YEAR } from '../../../../constants/index.js';
 import { ERC20Contract, ERC20_ABI } from '../../../erc-20/index.js';
 import { RatesConfig } from '../../config.js';
-import { BASE, fixed, getChain } from '../../helpers/index.js';
+import { BASE, fixed, getChain, stringify } from '../../helpers/index.js';
 import { EULER_MANTISSA, EULER_MARKETS_ABI, EULER_RESERVE_FEE_SCALE, EULER_TOKEN_ABI } from './constants.js';
 import { EulerMarketsContract, EulerTokenContract } from './types.js';
 
@@ -69,5 +69,5 @@ export async function interestRateEuler (a: string, s: Provider | Signer, c: Rat
     // finally we can compound the supply rate and derive the supply APY
     const supplyAPY = Math.pow(Number(supplyRate.toString()) + 1, SECONDS_PER_YEAR) - 1;
 
-    return supplyAPY.toString();
+    return stringify(supplyAPY);
 }

--- a/src/internal/rates/protocols/yearn/yearn.ts
+++ b/src/internal/rates/protocols/yearn/yearn.ts
@@ -2,7 +2,7 @@ import { Provider } from '@ethersproject/abstract-provider';
 import { Signer } from '@ethersproject/abstract-signer';
 import { Contract } from 'ethers';
 import { fetch, request, response } from '../../../fetch/index.js';
-import { BASE_DECIMALS, getChain } from '../../helpers/index.js';
+import { getChain, stringify } from '../../helpers/index.js';
 import { YEARN_ABI, YEARN_API } from './constants.js';
 import { YearnApiSchema, YearnVaultContract } from './types.js';
 
@@ -63,5 +63,5 @@ export async function interestRateYearn (a: string, s: Provider | Signer): Promi
 
     if (!vault) throw new Error(`Vault '${ a }' not found.`);
 
-    return vault.apy.net_apy.toFixed(BASE_DECIMALS);
+    return stringify(vault.apy.net_apy);
 }

--- a/test/internal/helpers.spec.ts
+++ b/test/internal/helpers.spec.ts
@@ -1,0 +1,66 @@
+import assert from 'assert';
+import { suite, test } from 'mocha';
+import { BASE_DECIMALS, stringify } from '../../src/internal/rates/helpers/index.js';
+
+suite('internal/helpers', () => {
+
+    suite('stringify', () => {
+
+        test('stringify number uses default decimals', () => {
+
+            // 30 decimals
+            const value = 0.123456789012345678901234567890;
+
+            // default decimals are 26 (`BASE_DECIMALS`)
+            const result = stringify(value);
+
+            // the length is decimals plus 2 (nominal digit plus decimal point plus fraction digits)
+            assert.strictEqual(result.length, 2 + BASE_DECIMALS);
+        });
+
+        test('stringify number can use custom decimals', () => {
+
+            // 30 decimals
+            const value = 0.123456789012345678901234567890;
+            const result = stringify(value, 5);
+
+            // the length is decimals plus 2 (nominal digit plus decimal point plus fraction digits)
+            assert.strictEqual(result.length, 7);
+        });
+
+        test('stringify number removes exponential notation', () => {
+
+            const value = 5e-26;
+            const result = stringify(value);
+
+            assert.strictEqual(result, '0.00000000000000000000000005');
+        });
+
+        test('stringify number removes trailing zeros', () => {
+
+            // 0.050.toFixed(10) would return '0.0500000000'
+            let value = 0.050;
+            let result = stringify(value, 10);
+
+            assert.strictEqual(result, '0.05');
+
+            // 0.5e-20.toFixed(26) would return '0.00000000000000000000500000'
+            value = 0.5e-20;
+            result = stringify(value);
+
+            assert.strictEqual(result, '0.000000000000000000005');
+
+            // (0).toFixed(26) would return '0.00000000000000000000000000'
+            value = 0;
+            result = stringify(value);
+
+            assert.strictEqual(result, '0.0');
+
+            // (1).toFixed(26) would return '1.00000000000000000000000000'
+            value = 1;
+            result = stringify(value);
+
+            assert.strictEqual(result, '1.0');
+        });
+    });
+});


### PR DESCRIPTION
don't return exponential notations for a principal's `interestRate`