### PR TITLE
fix: update lido's `interestRate` method

### DIFF
--- a/src/internal/rates/index.ts
+++ b/src/internal/rates/index.ts
@@ -91,7 +91,7 @@ export async function getInterestRate (p: Protocol, a: string, s: Provider | Sig
 
         case Protocols.Lido:
 
-            return await interestRateLido(a, s);
+            return await interestRateLido();
 
         case Protocols.Frax:
 

--- a/src/internal/rates/protocols/lido/constants.ts
+++ b/src/internal/rates/protocols/lido/constants.ts
@@ -4,7 +4,7 @@
  * @remarks
  * https://docs.lido.fi/contracts/lido#getfee
  */
-export const BASIS_POINTS = 10000;
+// export const BASIS_POINTS = 10000;
 
 /**
  * A minimal subset of Lido's wstETH ABI.
@@ -18,22 +18,8 @@ export const WSTETH_ABI = [
 ];
 
 /**
- * A minimal subset of Lido's (stETH) ABI.
- *
+ * The Lido API endpoint for APR.
  * @remarks
- * https://docs.lido.fi/contracts/lido
+ * https://docs.lido.fi/integrations/api#last-lido-apr-for-steth
  */
-export const LIDO_ABI = [
-    'function getFee() view returns (uint16)',
-    'function getOracle() view returns (address)',
-];
-
-/**
- * A minimal subset of Lido's Oracle ABI.
- *
- * @remarks
- * https://docs.lido.fi/contracts/lido-oracle
- */
-export const LIDO_ORACLE_ABI = [
-    'function getLastCompletedReportDelta() view returns (uint256 postTotalPooledEther, uint256 preTotalPooledEther, uint256 timeElapsed)',
-];
+export const LIDO_API = 'https://eth-api.lido.fi/v1/protocol/steth/apr/last';

--- a/src/internal/rates/protocols/lido/lido.ts
+++ b/src/internal/rates/protocols/lido/lido.ts
@@ -1,11 +1,10 @@
 import { Provider } from '@ethersproject/abstract-provider';
 import { Signer } from '@ethersproject/abstract-signer';
-import { BigNumber, Contract } from 'ethers';
-import { SECONDS_PER_YEAR } from '../../../../constants/index.js';
-import { unwrap } from '../../../../helpers/result.js';
-import { fixed } from '../../helpers/index.js';
-import { BASIS_POINTS, LIDO_ABI, LIDO_ORACLE_ABI, WSTETH_ABI } from './constants.js';
-import { LidoContract, LidoOracleContract, wstETHContract } from './types.js';
+import { Contract } from 'ethers';
+import { fetch, request, response } from '../../../fetch/index.js';
+import { stringify } from '../../helpers/index.js';
+import { LIDO_API, WSTETH_ABI } from './constants.js';
+import { LidoApiSchema, wstETHContract } from './types.js';
 
 /**
  * Lido's exchangeRate implementation.
@@ -28,47 +27,15 @@ export async function exchangeRateLido (a: string, s: Provider | Signer): Promis
  * Lido's interestRate implementation.
  *
  * @remarks
- * https://docs.lido.fi/contracts/lido-oracle#add-calculation-of-staker-rewards-apr
- *
- * A Lido market's `cTokenAddr` is the wstETH address.
+ * https://docs.lido.fi/integrations/api#last-lido-apr-for-steth
  *
  * @internal
  */
-export async function interestRateLido (a: string, s: Provider | Signer): Promise<string | undefined> {
+export async function interestRateLido (): Promise<string | undefined> {
 
-    const wstETH = new Contract(a, WSTETH_ABI, s) as wstETHContract;
+    const res = await fetch(request(LIDO_API, 'GET'));
 
-    // get the lido address from the wstETH contract
-    const lidoAddress = await wstETH.stETH();
+    const data = await response<LidoApiSchema>(res);
 
-    const lido = new Contract(lidoAddress, LIDO_ABI, s) as LidoContract;
-
-    // get the fee and the oracle address from the lido contract
-    const [fee, oracleAddress] = await Promise.all([
-        lido.getFee(),
-        lido.getOracle(),
-    ]);
-
-    const oracle = new Contract(oracleAddress, LIDO_ORACLE_ABI, s) as LidoOracleContract;
-
-    // get the data needed for calculating the APR from the oracle
-    const [
-        postTotalPooledEther,
-        preTotalPooledEther,
-        timeElapsed,
-    ] = unwrap<[BigNumber, BigNumber, BigNumber]>(await oracle.getLastCompletedReportDelta());
-
-    // decimals are based on ETH and that's enough precision for the rate
-    const d = 18;
-
-    // protocolAPR = (postTotalPooledEther - preTotalPooledEther) * secondsInYear / (preTotalPooledEther * timeElapsed)
-    const protocolAPR = fixed(postTotalPooledEther, d)
-        .subUnsafe(fixed(preTotalPooledEther, d))
-        .mulUnsafe(fixed(SECONDS_PER_YEAR, d))
-        .divUnsafe(fixed(preTotalPooledEther, d).mulUnsafe(fixed(timeElapsed, d)));
-
-    // userAPR = protocolAPR * (1 - lidoFee / basisPoint)
-    const userAPR = protocolAPR.mulUnsafe(fixed(1, d).subUnsafe(fixed(fee, d).divUnsafe(fixed(BASIS_POINTS, d))));
-
-    return userAPR.toString();
+    return stringify(data.data.apr / 100);
 }

--- a/src/internal/rates/protocols/lido/types.ts
+++ b/src/internal/rates/protocols/lido/types.ts
@@ -12,22 +12,19 @@ export interface wstETHContract extends Contract {
 }
 
 /**
- * An interface for a subset of Lido's (stETH) ABI.
+ * An interface for Lido's API response.
  *
  * @remarks
- * https://docs.lido.fi/contracts/lido
+ * https://eth-api.lido.fi/api/static/index.html#/APR%20for%20Eth%20and%20stEth/ProtocolController_findLastAPRforSTETH
  */
-export interface LidoContract extends Contract {
-    getFee (): Promise<number>;
-    getOracle (): Promise<string>;
-}
-
-/**
- * An interface for a subset of Lido's Oracle ABI.
- *
- * @remarks
- * https://docs.lido.fi/contracts/lido-oracle
- */
-export interface LidoOracleContract extends Contract {
-    getLastCompletedReportDelta (): Promise<[BigNumber, BigNumber, BigNumber]>;
+export interface LidoApiSchema {
+    data: {
+        timeUnix: number;
+        apr: number;
+    };
+    meta: {
+        symbol: string;
+        address: string;
+        chainId: number;
+    };
 }


### PR DESCRIPTION
the `LidoOracle` is deprecated and APRs can now be obtained via Lido's API